### PR TITLE
Add optional GPU acceleration

### DIFF
--- a/ptl_si/PTL_SI.py
+++ b/ptl_si/PTL_SI.py
@@ -4,10 +4,17 @@ import sub_prob
 import random
 import numpy as np
 
+try:
+    import cupy as cp
+    xp = cp
+except Exception:  # pragma: no cover - cupy might not be installed
+    cp = None
+    xp = np
+
 
 def divide_and_conquer_TF(X, X0, a, b, Mobs, N, nT, K, p, B, Q, lambda_0, lambda_tilde, ak_weights, z_min, z_max):
     z = z_min
-    a_tilde = np.concatenate([ak_weights[k] * np.ones(p) for k in range(K)] + [np.ones(p)]).reshape(-1, 1)
+    a_tilde = xp.concatenate([ak_weights[k] * xp.ones(p) for k in range(K)] + [xp.ones(p)]).reshape(-1, 1)
     intervals = []
     while z < z_max:
         Yz = a + b*z

--- a/ptl_si/sub_prob.py
+++ b/ptl_si/sub_prob.py
@@ -1,5 +1,21 @@
 import numpy as np
-from numpy.linalg import pinv
+try:
+    import cupy as cp
+    _GPU_AVAILABLE = True
+    xp = cp
+except Exception:  # pragma: no cover - cupy might not be installed
+    cp = None
+    _GPU_AVAILABLE = False
+    xp = np
+
+def _to_device(arr):
+    return cp.asarray(arr) if _GPU_AVAILABLE else np.asarray(arr)
+
+def _to_cpu(arr):
+    return cp.asnumpy(arr) if _GPU_AVAILABLE else arr
+
+def _pinv(mat):
+    return xp.linalg.pinv(mat)
 
 
 def _interval_bounds(psi, gamma):
@@ -18,33 +34,36 @@ def _interval_bounds(psi, gamma):
         Lower and upper bounds for the parameter.
     """
 
+    psi = _to_device(psi)
+    gamma = _to_device(gamma)
+
     if psi.size == 0:
         return [-np.inf, np.inf]
 
     mask_zero = psi == 0
-    if np.any(mask_zero & (gamma < 0)):
+    if xp.any(mask_zero & (gamma < 0)):
         return [np.inf, -np.inf]
 
     pos = psi > 0
     neg = psi < 0
 
-    ru = np.min(gamma[pos] / psi[pos]) if np.any(pos) else np.inf
-    lu = np.max(gamma[neg] / psi[neg]) if np.any(neg) else -np.inf
+    ru = xp.min(gamma[pos] / psi[pos]) if xp.any(pos) else xp.inf
+    lu = xp.max(gamma[neg] / psi[neg]) if xp.any(neg) else -xp.inf
 
-    return [lu, ru]
+    return [float(_to_cpu(lu)), float(_to_cpu(ru))]
 
 
 def compute_Zu(SO, O, XO, Oc, XOc, a, b, lambda_0, a_tilde, N):
     a_tilde_O = a_tilde[O]
     a_tilde_Oc = a_tilde[Oc]
 
-    psi0 = np.array([])
-    gamma0 = np.array([])
-    psi1 = np.array([])
-    gamma1 = np.array([])
+    psi0 = xp.array([])
+    gamma0 = xp.array([])
+    psi1 = xp.array([])
+    gamma1 = xp.array([])
 
     if len(O) > 0:
-        inv = pinv(XO.T @ XO)
+        inv = _pinv(XO.T @ XO)
         XO_plus = inv @ XO.T
 
         # Calculate psi0
@@ -60,11 +79,11 @@ def compute_Zu(SO, O, XO, Oc, XOc, a, b, lambda_0, a_tilde, N):
 
     if len(Oc) > 0:
         if len(O) == 0:
-            proj = np.eye(N)
+            proj = xp.eye(N)
             temp2 = 0
 
         else:
-            proj = np.eye(N) - XO @ XO_plus
+            proj = xp.eye(N) - XO @ XO_plus
             XO_O_plus = XO @ inv
             temp2 = (XOc.T @ XO_O_plus) @ (a_tilde_O * SO)
             temp2 = temp2 / a_tilde_Oc
@@ -74,16 +93,16 @@ def compute_Zu(SO, O, XO, Oc, XOc, a, b, lambda_0, a_tilde, N):
 
         # Calculate psi1
         term_b = temp1 @ b
-        psi1 = np.concatenate([term_b.ravel(), -term_b.ravel()])
+        psi1 = xp.concatenate([term_b.ravel(), -term_b.ravel()])
 
         # Calculate gamma1
         term_a = temp1 @ a
-        ones_vec = np.ones_like(term_a)
+        ones_vec = xp.ones_like(term_a)
 
-        gamma1 = np.concatenate([(ones_vec - temp2 - term_a).ravel(), (ones_vec + temp2 + term_a).ravel()])
+        gamma1 = xp.concatenate([(ones_vec - temp2 - term_a).ravel(), (ones_vec + temp2 + term_a).ravel()])
 
-    psi = np.concatenate((psi0, psi1))
-    gamma = np.concatenate((gamma0, gamma1))
+    psi = xp.concatenate((psi0, psi1))
+    gamma = xp.concatenate((gamma0, gamma1))
 
     lu = -np.inf
     ru = np.inf
@@ -104,17 +123,24 @@ def compute_Zu(SO, O, XO, Oc, XOc, a, b, lambda_0, a_tilde, N):
 
 
 def compute_Zu_ver2(SO, O, XO, Oc, XOc, a, b, lambda_0, a_tilde, N):
-    """Vectorized version of :func:`compute_Zu` for better performance."""
+    """Vectorized version of :func:`compute_Zu` with optional GPU acceleration."""
+    SO = _to_device(SO)
+    XO = _to_device(XO)
+    XOc = _to_device(XOc)
+    a = _to_device(a)
+    b = _to_device(b)
+    a_tilde = _to_device(a_tilde)
+
     a_tilde_O = a_tilde[O]
     a_tilde_Oc = a_tilde[Oc]
 
-    psi0 = np.array([])
-    gamma0 = np.array([])
-    psi1 = np.array([])
-    gamma1 = np.array([])
+    psi0 = xp.array([])
+    gamma0 = xp.array([])
+    psi1 = xp.array([])
+    gamma1 = xp.array([])
 
     if len(O) > 0:
-        inv = pinv(XO.T @ XO)
+        inv = _pinv(XO.T @ XO)
         XO_plus = inv @ XO.T
 
         XO_plus_b = XO_plus @ b
@@ -127,10 +153,10 @@ def compute_Zu_ver2(SO, O, XO, Oc, XOc, a, b, lambda_0, a_tilde, N):
 
     if len(Oc) > 0:
         if len(O) == 0:
-            proj = np.eye(N)
+            proj = xp.eye(N)
             temp2 = 0
         else:
-            proj = np.eye(N) - XO @ XO_plus
+            proj = xp.eye(N) - XO @ XO_plus
             XO_O_plus = XO @ inv
             temp2 = (XOc.T @ XO_O_plus) @ (a_tilde_O * SO)
             temp2 = temp2 / a_tilde_Oc
@@ -139,29 +165,29 @@ def compute_Zu_ver2(SO, O, XO, Oc, XOc, a, b, lambda_0, a_tilde, N):
         temp1 = (XOc_O_proj / a_tilde_Oc) / (lambda_0 * N)
 
         term_b = temp1 @ b
-        psi1 = np.concatenate([term_b.ravel(), -term_b.ravel()])
+        psi1 = xp.concatenate([term_b.ravel(), -term_b.ravel()])
 
         term_a = temp1 @ a
-        ones_vec = np.ones_like(term_a)
-        gamma1 = np.concatenate([(ones_vec - temp2 - term_a).ravel(),
+        ones_vec = xp.ones_like(term_a)
+        gamma1 = xp.concatenate([(ones_vec - temp2 - term_a).ravel(),
                                  (ones_vec + temp2 + term_a).ravel()])
 
-    psi = np.concatenate((psi0, psi1))
-    gamma = np.concatenate((gamma0, gamma1))
+    psi = xp.concatenate((psi0, psi1))
+    gamma = xp.concatenate((gamma0, gamma1))
 
-    return _interval_bounds(psi, gamma)
+    return _interval_bounds(_to_cpu(psi), _to_cpu(gamma))
 
 def compute_Zv(SL, L, X0L, Lc, X0Lc, phi_u, iota_u, a, b, lambda_tilde, nT):
-    nu0 = np.array([])
-    kappa0 = np.array([])
-    nu1 = np.array([])
-    kappa1 = np.array([])
+    nu0 = xp.array([])
+    kappa0 = xp.array([])
+    nu1 = xp.array([])
+    kappa1 = xp.array([])
 
     phi_a_iota = (phi_u @  a) + iota_u
     phi_b = phi_u @ b
 
     if len(L) > 0:
-        inv = pinv(X0L.T @ X0L)
+        inv = _pinv(X0L.T @ X0L)
         X0L_plus = inv @ X0L.T
 
         # Calculate nu0
@@ -176,11 +202,11 @@ def compute_Zv(SL, L, X0L, Lc, X0Lc, phi_u, iota_u, a, b, lambda_tilde, nT):
 
     if len(Lc) > 0:
         if len(L) == 0:
-            proj = np.eye(nT)
+            proj = xp.eye(nT)
             temp2 = 0
 
         else:
-            proj = np.eye(nT) - X0L@X0L_plus
+            proj = xp.eye(nT) - X0L@X0L_plus
 
             X0L_T_plus = X0L @ inv
             temp2 = (X0Lc.T @ X0L_T_plus) @ SL
@@ -191,15 +217,15 @@ def compute_Zv(SL, L, X0L, Lc, X0Lc, phi_u, iota_u, a, b, lambda_tilde, nT):
 
         # Calculate nu1
         term_b = temp1 @ phi_b
-        nu1 = np.concatenate([term_b.ravel(), -term_b.ravel()])
+        nu1 = xp.concatenate([term_b.ravel(), -term_b.ravel()])
 
         # Calculate kappa1
         term_a = temp1 @ phi_a_iota
-        ones_vec = np.ones_like(term_a)
-        kappa1 = np.concatenate([(ones_vec - temp2 - term_a).ravel(), (ones_vec + temp2 + term_a).ravel()])
+        ones_vec = xp.ones_like(term_a)
+        kappa1 = xp.concatenate([(ones_vec - temp2 - term_a).ravel(), (ones_vec + temp2 + term_a).ravel()])
 
-    nu = np.concatenate((nu0, nu1))
-    kappa = np.concatenate((kappa0, kappa1))
+    nu = xp.concatenate((nu0, nu1))
+    kappa = xp.concatenate((kappa0, kappa1))
 
     lv = -np.inf
     rv = np.inf
@@ -221,17 +247,25 @@ def compute_Zv(SL, L, X0L, Lc, X0Lc, phi_u, iota_u, a, b, lambda_tilde, nT):
 
 
 def compute_Zv_ver2(SL, L, X0L, Lc, X0Lc, phi_u, iota_u, a, b, lambda_tilde, nT):
-    """Vectorized version of :func:`compute_Zv` for better performance."""
-    nu0 = np.array([])
-    kappa0 = np.array([])
-    nu1 = np.array([])
-    kappa1 = np.array([])
+    """Vectorized version of :func:`compute_Zv` with optional GPU acceleration."""
+    SL = _to_device(SL)
+    X0L = _to_device(X0L)
+    X0Lc = _to_device(X0Lc)
+    phi_u = _to_device(phi_u)
+    iota_u = _to_device(iota_u)
+    a = _to_device(a)
+    b = _to_device(b)
+
+    nu0 = xp.array([])
+    kappa0 = xp.array([])
+    nu1 = xp.array([])
+    kappa1 = xp.array([])
 
     phi_a_iota = (phi_u @ a) + iota_u
     phi_b = phi_u @ b
 
     if len(L) > 0:
-        inv = pinv(X0L.T @ X0L)
+        inv = _pinv(X0L.T @ X0L)
         X0L_plus = inv @ X0L.T
 
         X0L_plus_phi_b = X0L_plus @ phi_b
@@ -244,10 +278,10 @@ def compute_Zv_ver2(SL, L, X0L, Lc, X0Lc, phi_u, iota_u, a, b, lambda_tilde, nT)
 
     if len(Lc) > 0:
         if len(L) == 0:
-            proj = np.eye(nT)
+            proj = xp.eye(nT)
             temp2 = 0
         else:
-            proj = np.eye(nT) - X0L @ X0L_plus
+            proj = xp.eye(nT) - X0L @ X0L_plus
             X0L_T_plus = X0L @ inv
             temp2 = (X0Lc.T @ X0L_T_plus) @ SL
 
@@ -255,24 +289,24 @@ def compute_Zv_ver2(SL, L, X0L, Lc, X0Lc, phi_u, iota_u, a, b, lambda_tilde, nT)
         temp1 = X0Lc_T_proj / (lambda_tilde * nT)
 
         term_b = temp1 @ phi_b
-        nu1 = np.concatenate([term_b.ravel(), -term_b.ravel()])
+        nu1 = xp.concatenate([term_b.ravel(), -term_b.ravel()])
 
         term_a = temp1 @ phi_a_iota
-        ones_vec = np.ones_like(term_a)
-        kappa1 = np.concatenate([(ones_vec - temp2 - term_a).ravel(),
+        ones_vec = xp.ones_like(term_a)
+        kappa1 = xp.concatenate([(ones_vec - temp2 - term_a).ravel(),
                                  (ones_vec + temp2 + term_a).ravel()])
 
-    nu = np.concatenate((nu0, nu1))
-    kappa = np.concatenate((kappa0, kappa1))
+    nu = xp.concatenate((nu0, nu1))
+    kappa = xp.concatenate((kappa0, kappa1))
 
-    return _interval_bounds(nu, kappa)
+    return _interval_bounds(_to_cpu(nu), _to_cpu(kappa))
 
 
 def compute_Zt(M, SM, Mc, xi_uv, zeta_uv, a, b):
-    omega0 = np.array([])
-    rho0 = np.array([])
-    omega1 = np.array([])
-    rho1 = np.array([])
+    omega0 = xp.array([])
+    rho0 = xp.array([])
+    omega1 = xp.array([])
+    rho1 = xp.array([])
 
     xi_a_zeta = (xi_uv @  a) + zeta_uv
     xi_b = xi_uv @ b
@@ -290,11 +324,11 @@ def compute_Zt(M, SM, Mc, xi_uv, zeta_uv, a, b):
         Dtc_xi_b = xi_b[Mc]
 
         # Calculate omega1, rho1
-        omega1 = np.concatenate([Dtc_xi_b.ravel(), -Dtc_xi_b.ravel()])
-        rho1 = np.concatenate([-Dtc_xi_a_zeta.ravel(), Dtc_xi_a_zeta.ravel()])
+        omega1 = xp.concatenate([Dtc_xi_b.ravel(), -Dtc_xi_b.ravel()])
+        rho1 = xp.concatenate([-Dtc_xi_a_zeta.ravel(), Dtc_xi_a_zeta.ravel()])
 
-    omega = np.concatenate((omega0, omega1))
-    rho = np.concatenate((rho0, rho1))
+    omega = xp.concatenate((omega0, omega1))
+    rho = xp.concatenate((rho0, rho1))
 
     lt = -np.inf
     rt = np.inf
@@ -316,11 +350,17 @@ def compute_Zt(M, SM, Mc, xi_uv, zeta_uv, a, b):
 
 
 def compute_Zt_ver2(M, SM, Mc, xi_uv, zeta_uv, a, b):
-    """Vectorized version of :func:`compute_Zt` for better performance."""
-    omega0 = np.array([])
-    rho0 = np.array([])
-    omega1 = np.array([])
-    rho1 = np.array([])
+    """Vectorized version of :func:`compute_Zt` with optional GPU acceleration."""
+    SM = _to_device(SM)
+    xi_uv = _to_device(xi_uv)
+    zeta_uv = _to_device(zeta_uv)
+    a = _to_device(a)
+    b = _to_device(b)
+
+    omega0 = xp.array([])
+    rho0 = xp.array([])
+    omega1 = xp.array([])
+    rho1 = xp.array([])
 
     xi_a_zeta = (xi_uv @ a) + zeta_uv
     xi_b = xi_uv @ b
@@ -336,22 +376,29 @@ def compute_Zt_ver2(M, SM, Mc, xi_uv, zeta_uv, a, b):
         Dtc_xi_a_zeta = xi_a_zeta[Mc]
         Dtc_xi_b = xi_b[Mc]
 
-        omega1 = np.concatenate([Dtc_xi_b.ravel(), -Dtc_xi_b.ravel()])
-        rho1 = np.concatenate([-Dtc_xi_a_zeta.ravel(), Dtc_xi_a_zeta.ravel()])
+        omega1 = xp.concatenate([Dtc_xi_b.ravel(), -Dtc_xi_b.ravel()])
+        rho1 = xp.concatenate([-Dtc_xi_a_zeta.ravel(), Dtc_xi_a_zeta.ravel()])
 
-    omega = np.concatenate((omega0, omega1))
-    rho = np.concatenate((rho0, rho1))
+    omega = xp.concatenate((omega0, omega1))
+    rho = xp.concatenate((rho0, rho1))
 
-    return _interval_bounds(omega, rho)
+    return _interval_bounds(_to_cpu(omega), _to_cpu(rho))
 
 def compute_Zu_otl(SO, O, XIO, Oc, XIOc, a, b, P, lambda_w, nI):
-    psi0 = np.array([])
-    gamma0 = np.array([])
-    psi1 = np.array([])
-    gamma1 = np.array([])
+    SO = _to_device(SO)
+    XIO = _to_device(XIO)
+    XIOc = _to_device(XIOc)
+    a = _to_device(a)
+    b = _to_device(b)
+    P = _to_device(P)
+
+    psi0 = xp.array([])
+    gamma0 = xp.array([])
+    psi1 = xp.array([])
+    gamma1 = xp.array([])
 
     if len(O) > 0:
-        inv = pinv(XIO.T @ XIO)
+        inv = _pinv(XIO.T @ XIO)
         XIO_plus = inv @ XIO.T
 
         # Calculate psi0
@@ -367,11 +414,11 @@ def compute_Zu_otl(SO, O, XIO, Oc, XIOc, a, b, P, lambda_w, nI):
 
     if len(Oc) > 0:
         if len(O) == 0:
-            proj = np.eye(nI)
+            proj = xp.eye(nI)
             temp2 = 0
 
         else:
-            proj = np.eye(nI) - XIO @ XIO_plus
+            proj = xp.eye(nI) - XIO @ XIO_plus
             XIO_T_plus = XIO @ inv
             temp2 = (XIOc.T @ XIO_T_plus) @ SO
 
@@ -380,17 +427,17 @@ def compute_Zu_otl(SO, O, XIO, Oc, XIOc, a, b, P, lambda_w, nI):
 
         # Calculate psi1
         term_Pb = temp1 @ P @ b
-        psi1 = np.concatenate([term_Pb.ravel(), - term_Pb.ravel()])
+        psi1 = xp.concatenate([term_Pb.ravel(), - term_Pb.ravel()])
 
         # Calculate gamma1
         term_Pa = temp1 @ P @ a
-        ones_vec = np.ones_like(term_Pa)
+        ones_vec = xp.ones_like(term_Pa)
 
-        gamma1 = np.concatenate([(ones_vec - temp2 - term_Pa).ravel(), (ones_vec + temp2 + term_Pa).ravel()])
+        gamma1 = xp.concatenate([(ones_vec - temp2 - term_Pa).ravel(), (ones_vec + temp2 + term_Pa).ravel()])
 
 
-    psi = np.concatenate((psi0, psi1))
-    gamma = np.concatenate((gamma0, gamma1))
+    psi = xp.concatenate((psi0, psi1))
+    gamma = xp.concatenate((gamma0, gamma1))
 
     lu = -np.inf
     ru = np.inf
@@ -411,15 +458,15 @@ def compute_Zu_otl(SO, O, XIO, Oc, XIOc, a, b, P, lambda_w, nI):
     return [lu, ru]
 
 def calculate_phi_iota_xi_zeta(X, SO, O, XO, X0, SL, L, X0L, p, B, Q, lambda_0, lambda_tilde, a_tilde, N, nT):
-    phi_u = Q.copy()
-    iota_u = np.zeros((nT, 1))
-    xi_uv = np.zeros((p, N))
-    zeta_uv = np.zeros((p, 1))
+    phi_u = _to_device(Q.copy())
+    iota_u = xp.zeros((nT, 1))
+    xi_uv = xp.zeros((p, N))
+    zeta_uv = xp.zeros((p, 1))
 
     if len(O) > 0:
         a_tilde_O = a_tilde[O]
-        Eu = np.eye(X.shape[1])[:, O]
-        inv_XOT_XO = pinv(XO.T @ XO)
+        Eu = xp.eye(X.shape[1])[:, O]
+        inv_XOT_XO = _pinv(XO.T @ XO)
         XO_plus = inv_XOT_XO @ XO.T
         X0_B_Eu = X0 @ B @ Eu
         B_Eu_inv_XOT_XO = B @ Eu @ inv_XOT_XO
@@ -431,25 +478,25 @@ def calculate_phi_iota_xi_zeta(X, SO, O, XO, X0, SL, L, X0L, p, B, Q, lambda_0, 
         zeta_uv += -lambda_0 * B_Eu_inv_XOT_XO @ (a_tilde_O * SO)
 
     if len(L) > 0:
-        Fv = np.eye(p)[:, L]
-        inv_X0LT_X0L = pinv(X0L.T @ X0L)
+        Fv = xp.eye(p)[:, L]
+        inv_X0LT_X0L = _pinv(X0L.T @ X0L)
         X0L_plus = inv_X0LT_X0L @ X0L.T
 
         xi_uv += Fv @ X0L_plus @ phi_u
         zeta_uv += Fv @ inv_X0LT_X0L @ (X0L.T @ iota_u - (nT * lambda_tilde) * SL)
 
-    return phi_u, iota_u, xi_uv, zeta_uv
+    return _to_cpu(phi_u), _to_cpu(iota_u), _to_cpu(xi_uv), _to_cpu(zeta_uv)
 
 
 def calculate_phi_iota_xi_zeta_otl(XI, SO, O, XIO, X0, SL, L, X0L, p, Q, P, lambda_w, lambda_del, nI, nT):
-    phi_u = Q.copy()
-    iota_u = np.zeros((nT, 1))
-    xi_uv = np.zeros((p, nI + nT))
-    zeta_uv = np.zeros((p, 1))
+    phi_u = _to_device(Q.copy())
+    iota_u = xp.zeros((nT, 1))
+    xi_uv = xp.zeros((p, nI + nT))
+    zeta_uv = xp.zeros((p, 1))
 
     if len(O) > 0:
-        Eu = np.eye(XI.shape[1])[:, O]
-        inv_XIO_T_XIO = pinv(XIO.T @ XIO)
+        Eu = xp.eye(XI.shape[1])[:, O]
+        inv_XIO_T_XIO = _pinv(XIO.T @ XIO)
         XIO_plus = inv_XIO_T_XIO @ XIO.T
         X0_Eu = X0 @ Eu
 
@@ -459,11 +506,11 @@ def calculate_phi_iota_xi_zeta_otl(XI, SO, O, XIO, X0, SL, L, X0L, p, Q, P, lamb
         zeta_uv += -(nI * lambda_w) * (Eu @  inv_XIO_T_XIO @ SO)
 
     if len(L) > 0:
-        Fv = np.eye(p)[:, L]
-        inv_X0L_T_X0L = pinv(X0L.T @ X0L)
+        Fv = xp.eye(p)[:, L]
+        inv_X0L_T_X0L = _pinv(X0L.T @ X0L)
         X0L_plus = inv_X0L_T_X0L @ X0L.T
 
         xi_uv += Fv @ X0L_plus @ phi_u
         zeta_uv += Fv @ inv_X0L_T_X0L @ (X0L.T @ iota_u - (nT * lambda_del) * SL)
 
-    return phi_u, iota_u, xi_uv, zeta_uv
+    return _to_cpu(phi_u), _to_cpu(iota_u), _to_cpu(xi_uv), _to_cpu(zeta_uv)


### PR DESCRIPTION
## Summary
- enable optional GPU support via CuPy if available
- accelerate subproblem calculations using GPU arrays
- update PTL_SI to create GPU-friendly arrays

## Testing
- `python -m py_compile ptl_si/sub_prob.py ptl_si/PTL_SI.py`
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_6853c7012718832ca68f55a909b1fccc