### PR TITLE
Add multiprocessing support for p-value computation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,9 @@ We provide several Jupyter notebooks demonstrating how to use the `ptl_si` packa
   - `ex1_p_value_TF.ipynb` - Example for computing p-value for TransFusion
   - `ex2_p_value_OTL.ipynb` -  Example for computing p-value for Oracle Trans-Lasso
   - `ex3_pivot.ipynb` - Check the uniformity of the pivot
+
+## Parallel Execution
+
+The main inference routines `PTL_SI_TF` and `PTL_SI_OTL` accept an optional
+`n_jobs` argument.  When set to a value greater than one, p-values for different
+selected features are computed in parallel using multiple processes.


### PR DESCRIPTION
## Summary
- add optional `n_jobs` param for `PTL_SI_TF` and `PTL_SI_OTL`
- compute per-feature p-values in parallel with `ProcessPoolExecutor`
- document parallel execution in README

## Testing
- `python -m py_compile ptl_si/PTL_SI.py`

------
https://chatgpt.com/codex/tasks/task_e_6853d6c5fe48832c973f8bef9a70eba2